### PR TITLE
Work around Hand Warmer bypass

### DIFF
--- a/Freeze/main.cs
+++ b/Freeze/main.cs
@@ -60,7 +60,7 @@ namespace Freeze
                     continue;
 
                 if (frozenplayer.Contains(ts.IP))
-                    frozenplayer.Disable("Manually frozen with command", false)
+                    ts.Disable("Manually frozen with command", false);
             }
         }
 

--- a/Freeze/main.cs
+++ b/Freeze/main.cs
@@ -60,11 +60,7 @@ namespace Freeze
                     continue;
 
                 if (frozenplayer.Contains(ts.IP))
-                {
-                    ts.SetBuff(47, 180, true);
-                    ts.SetBuff(80, 180, true);
-                    ts.SetBuff(23, 180, true);
-                }
+                    frozenplayer.Disable("Manually frozen with command", false)
             }
         }
 


### PR DESCRIPTION
As /freeze command is supposed to prevent player from moving, thus implying disallowing player to interact with the world. Using TShock's built-in Disable() method will make freezing more effective and can't be bypassed with Hand Warmer.